### PR TITLE
git clone via http:// was not working for me; this patch fixes that.

### DIFF
--- a/oab-java6.sh
+++ b/oab-java6.sh
@@ -246,7 +246,7 @@ pid=$!;progress $pid
 # Clone the code
 ncecho " [x] Cloning https://github.com/rraptorr/sun-java6 "
 cd /var/local/oab/ >> "$log" 2>&1
-git clone https://github.com/rraptorr/sun-java6 src >> "$log" 2>&1 &
+git clone git://github.com/rraptorr/sun-java6.git src >> "$log" 2>&1 &
 pid=$!;progress $pid
 
 # Get the last commit tag.


### PR DESCRIPTION
Old path would error out with:
  warning: remote HEAD refers to nonexistent ref, unable to checkout.
