### PR TITLE
Allow the script to skip the build if the packages have already been built

### DIFF
--- a/oab-java6.sh
+++ b/oab-java6.sh
@@ -64,6 +64,7 @@ function usage() {
     echo "  sudo ${0}"
     echo
     echo "Optional parameters"
+    echo "  -s : Skip building if the package exists"
     echo "  -c : Remove pre-existing packages from '/var/local/oab/deb'"
     echo "  -h : This help"
     echo
@@ -196,7 +197,7 @@ BUILD_KEY=""
 BUILD_CLEAN=0
 
 # Parse the options
-OPTSTRING=bchk:
+OPTSTRING=bchk:s
 while getopts ${OPTSTRING} OPT
 do
     case ${OPT} in
@@ -204,6 +205,7 @@ do
         c) BUILD_CLEAN=1;;
         h) usage;;
         k) BUILD_KEY=${OPTARG};;
+        s) SKIP_REBUILD=1;;
         *) usage;;
     esac
 done
@@ -302,6 +304,11 @@ done
 
 # Determine the new version
 NEW_VERSION="${DEB_VERSION}~${LSB_CODE}1"
+
+if [ -n "$SKIP_REBUILD" -a -r "/var/local/oab/deb/sun-java${JAVA_VER}_${NEW_VERSION}_${LSB_ARCH}.changes" ]; then
+  echo " [x] Package exists, skipping build "
+  exit
+fi
 
 # Genereate a build message
 BUILD_MESSAGE="Automated build for ${LSB_REL} using https://github.com/rraptorr/sun-java6"


### PR DESCRIPTION
Awesome script! I would like to run it as part of periodic updates, but currently that means a full build of the packages every time. This is a very minor tweak to skip rebuilding if requested and the packages already exist. Currently just basing it on the existence of the "changes" file, but if that's not sufficient checking for the debs specifically wouldn't be much harder.
