### PR TITLE
Downloads from oracle.com failing again

### DIFF
--- a/oab-java6.sh
+++ b/oab-java6.sh
@@ -275,7 +275,7 @@ pid=$!;progress $pid
 
 # See if the Java version is on the download frontpage, otherwise look for it in
 # the previous releases page.
-DOWNLOAD_INDEX=`grep "/technetwork/java/javase/downloads/jdk-${JAVA_VER}u${JAVA_UPD}" /tmp/oab-index.html | grep "alt=\"Download JDK\"" | cut -d'<' -f3 | cut -d'"' -f2`
+DOWNLOAD_INDEX=`grep -P -o "/technetwork/java/javase/downloads/jdk-${JAVA_VER}u${JAVA_UPD}-downloads-\d+\.html" /tmp/oab-index.html | uniq`
 if [ -n "${DOWNLOAD_INDEX}" ]; then
     ncecho " [x] Getting current release download page "
     wget http://www.oracle.com/${DOWNLOAD_INDEX} -O /tmp/oab-download.html >> "$log" 2>&1 &


### PR DESCRIPTION
rraptorr updated sun-java6 for update 32.  Oracle split out the demos but the link goes to the same download page.  This change, or some other change Oracle made to the page breaks the line that sets DOWNLOAD_INDEX.

I changed it to use a Perl-compatible regex (works with Ubuntu 10.04 and up) and output the matched string.  It then filters that through uniq to get a single string.  "head -1" might have been a better idea but this worked for me.

My first pull request.  Be gentle.  :-)
