### PR TITLE
Update README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -29,7 +29,7 @@ Like this.
 ::
 
   cd ~/
-  wget https://github.com/flexiondotorg/oab-java6/raw/0.2.5/oab-java.sh -O oab-java.sh
+  wget https://raw.github.com/flexiondotorg/oab-java6/master/oab-java.sh -O oab-java.sh
   chmod +x oab-java.sh
   sudo ./oab-java.sh
 


### PR DESCRIPTION
Hi flexiondotorg, 
I think the `wget` line in the `README.rst` should point to master of the `oab-java.sh` script. People tend to copy and paste the line and keep getting an older version which fails to download Java6 from Oracle's server.
