### PR TITLE
remove imvirt dependency and fix openvz check

### DIFF
--- a/oab-java.sh
+++ b/oab-java.sh
@@ -381,7 +381,7 @@ fi
 
 # Determine the build and runtime requirements.
 BUILD_DEPS="build-essential debhelper defoma devscripts dpkg-dev git-core \
-gnupg imvirt libasound2 libxi6 libxt6 libxtst6 rng-tools unixodbc unzip"
+gnupg libasound2 libxi6 libxt6 libxtst6 rng-tools unixodbc unzip"
 if [ "${LSB_ARCH}" == "amd64" ]; then
     BUILD_DEPS="${BUILD_DEPS} lib32asound2 ia32-libs"
 fi
@@ -588,33 +588,35 @@ do
 done
 cecho success
 
-# Skip anything todo with automated key creation if this script is running in
-# an OpenVZ container.
-if [[ `imvirt` != "OpenVZ" ]]; then
-    # Do we need to create signing keys
-    if [ -z "${BUILD_KEY}" ] && [ ! -e ${WORK_PATH}/gpg/pubring.gpg ] && [ ! -e ${WORK_PATH}/gpg/secring.gpg ] && [ ! -e ${WORK_PATH}/gpg/trustdb.gpg ]; then
+# Do we need to create signing keys
+if [ -z "${BUILD_KEY}" ] && [ ! -e ${WORK_PATH}/gpg/pubring.gpg ] && [ ! -e ${WORK_PATH}/gpg/secring.gpg ] && [ ! -e ${WORK_PATH}/gpg/trustdb.gpg ]; then
 
-        ncecho " [x] Create GnuPG configuration "
-        echo "Key-Type: DSA" > ${WORK_PATH}/gpg-key.conf
-        echo "Key-Length: 1024" >> ${WORK_PATH}/gpg-key.conf
-        echo "Subkey-Type: ELG-E" >> ${WORK_PATH}/gpg-key.conf
-        echo "Subkey-Length: 2048" >> ${WORK_PATH}/gpg-key.conf
-        echo "Name-Real: `hostname --fqdn`" >> ${WORK_PATH}/gpg-key.conf
-        echo "Name-Email: root@`hostname --fqdn`" >> ${WORK_PATH}/gpg-key.conf
-        echo "Expire-Date: 0" >> ${WORK_PATH}/gpg-key.conf
-        cecho success
+    ncecho " [x] Create GnuPG configuration "
+    echo "Key-Type: DSA" > ${WORK_PATH}/gpg-key.conf
+    echo "Key-Length: 1024" >> ${WORK_PATH}/gpg-key.conf
+    echo "Subkey-Type: ELG-E" >> ${WORK_PATH}/gpg-key.conf
+    echo "Subkey-Length: 2048" >> ${WORK_PATH}/gpg-key.conf
+    echo "Name-Real: `hostname --fqdn`" >> ${WORK_PATH}/gpg-key.conf
+    echo "Name-Email: root@`hostname --fqdn`" >> ${WORK_PATH}/gpg-key.conf
+    echo "Expire-Date: 0" >> ${WORK_PATH}/gpg-key.conf
+    cecho success
 
+    # OpenVZ Check... Don't run if in OpenVZ
+    if [ ! -e /proc/user_beancounters ]; then
         # Stop the system 'rngd'.
         /etc/init.d/rng-tools stop >> "$log" 2>&1
 
         ncecho " [x] Start generating entropy "  
         rngd -r /dev/urandom -p /tmp/rngd.pid >> "$log" 2>&1 &
         pid=$!;progress $pid
+    fi
 
-        ncecho " [x] Creating signing key "
-        gpg --homedir ${WORK_PATH}/gpg --batch --gen-key ${WORK_PATH}/gpg-key.conf >> "$log" 2>&1 &
-        pid=$!;progress $pid
+    ncecho " [x] Creating signing key "
+    gpg --homedir ${WORK_PATH}/gpg --batch --gen-key ${WORK_PATH}/gpg-key.conf >> "$log" 2>&1 &
+    pid=$!;progress $pid
 
+    # OpenVZ Check... Don't run if in OpenVZ (same as above)
+    if [ ! -e /proc/user_beancounters ]; then
         ncecho " [x] Stop generating entropy "
         kill -9 `cat /tmp/rngd.pid` >> "$log" 2>&1 &
         pid=$!;progress $pid
@@ -624,7 +626,6 @@ if [[ `imvirt` != "OpenVZ" ]]; then
         /etc/init.d/rng-tools start >> "$log" 2>&1
     fi
 fi
-
 # Do we have signing keys or a user specified key, if so use them.
 if [ -n "${BUILD_KEY}" ] || [ -e ${WORK_PATH}/gpg/pubring.gpg ] && [ -e ${WORK_PATH}/gpg/secring.gpg ] && [ -e ${WORK_PATH}/gpg/trustdb.gpg ]; then
     # Sign the Release

--- a/oab-java.sh
+++ b/oab-java.sh
@@ -418,7 +418,7 @@ pid=$!;progress $pid
 
 # Get the last commit tag.
 cd ${WORK_PATH}/src >> "$log" 2>&1
-TAG=`git tag -l | tail -n1`
+TAG=`git tag -l | sort -V | tail -n1`
 
 # Checkout the tagged, stable, version.
 ncecho " [x] Checking out ${TAG} "


### PR DESCRIPTION
imvirt doesn't work properly on openvz anymore so the script tries to run the entropy daemon anyways. I fixed the check to look for /proc/user_beancounters instead which only exists on openvz (to my knowledge). If it exists then it skips the parts relating to rngd only. It will still generate a key however. Before you blocked out the entire segment on openvz.

shinji257@0a34812#oab-java

Tested on OpenVZ and Xen PV.

Edit: Closed #70 since I have the pull request here.
