### PR TITLE
Fix for issue #74

### DIFF
--- a/oab-java.sh
+++ b/oab-java.sh
@@ -418,7 +418,7 @@ pid=$!;progress $pid
 
 # Get the last commit tag.
 cd ${WORK_PATH}/src >> "$log" 2>&1
-TAG=`git tag -l | tail -n1`
+TAG=`git tag -l | sort -V | tail -n1`
 
 # Checkout the tagged, stable, version.
 ncecho " [x] Checking out ${TAG} "


### PR DESCRIPTION
sort Tag list as a list of version numbers so that
the correct "last" or "most current" tag is picked
