### PR TITLE
Get the correct rraptorr tag

### DIFF
--- a/oab-java.sh
+++ b/oab-java.sh
@@ -418,7 +418,7 @@ pid=$!;progress $pid
 
 # Get the last commit tag.
 cd ${WORK_PATH}/src >> "$log" 2>&1
-TAG=`git tag -l | tail -n1`
+TAG=`git describe --abbrev=0 --tags`
 
 # Checkout the tagged, stable, version.
 ncecho " [x] Checking out ${TAG} "


### PR DESCRIPTION
Because of the alphabetical sorting of the `git tag` command it would still get tag 7.9 instead of 7.11 from rraptorr repository. The `git describe --abbrev=0 --tags` command always loads the latest tag.
