### PR TITLE
No longer need both Java binary files for Java7

### DIFF
--- a/oab-java.sh
+++ b/oab-java.sh
@@ -418,7 +418,7 @@ pid=$!;progress $pid
 
 # Get the last commit tag.
 cd ${WORK_PATH}/src >> "$log" 2>&1
-TAG=`git tag -l | tail -n1`
+TAG=`git describe --abbrev=0 --tags`
 
 # Checkout the tagged, stable, version.
 ncecho " [x] Checking out ${TAG} "

--- a/oab-java.sh
+++ b/oab-java.sh
@@ -457,9 +457,20 @@ fi
 
 # Set the files we're downloading since sun-java6 and oracle-java7 differ.
 if [ "${JAVA_UPSTREAM}" == "sun-java6" ]; then
-    JAVA_BINS="jdk-${JAVA_VER}u${JAVA_UPD}-linux-i586.bin jdk-${JAVA_VER}u${JAVA_UPD}-linux-x64.bin"
+    JAVA_EXT=.bin
 else
-    JAVA_BINS="jdk-${JAVA_VER}u${JAVA_UPD}-linux-i586.tar.gz jdk-${JAVA_VER}u${JAVA_UPD}-linux-x64.tar.gz"
+    JAVA_EXT=.tar.gz
+fi
+if grep -q ia32 ${WORK_PATH}/src/debian/rules; then
+    # Upstream still builds ia32 package, download both architectures
+    JAVA_BINS="jdk-${JAVA_VER}u${JAVA_UPD}-linux-i586${JAVA_EXT} jdk-${JAVA_VER}u${JAVA_UPD}-linux-x64${JAVA_EXT}"
+else
+    # Upstream has removed ia32 package, just download the appropriate one
+    if [ "${LSB_ARCH}" == "amd64" ]; then
+        JAVA_BINS="jdk-${JAVA_VER}u${JAVA_UPD}-linux-x64${JAVA_EXT}"
+    else
+        JAVA_BINS="jdk-${JAVA_VER}u${JAVA_UPD}-linux-i586${JAVA_EXT}"
+    fi
 fi
 
 for JAVA_BIN in ${JAVA_BINS}


### PR DESCRIPTION
See: https://github.com/rraptorr/oracle-java7/commit/1591b3a6b2b2caefc9f0be690c9141372d4640bf

This patch depends on https://github.com/flexiondotorg/oab-java6/pull/80 as only 7u10+ are affected. 
