### PR TITLE
Fix for Java 6u39

### DIFF
--- a/oab-java.sh
+++ b/oab-java.sh
@@ -449,7 +449,7 @@ pid=$!;progress $pid
 
 # See if the Java version is on the download frontpage, otherwise look for it in
 # the previous releases page.
-DOWNLOAD_INDEX="$(egrep -o /technetwork/java/javase/downloads/jdk"$JAVA_VER(u$JAVA_UPD)?"-downloads-[[:digit:]]+\\.html /tmp/oab-index.html | head -1)"
+DOWNLOAD_INDEX="$(egrep -o /technetwork/java/javase/downloads/jdk"$JAVA_VER(u$JAVA_UPD)?"-?downloads-[[:digit:]]+\\.html /tmp/oab-index.html | head -1)"
 ncecho " [x] Getting current release download page "
 wget http://www.oracle.com/${DOWNLOAD_INDEX} -O /tmp/oab-download.html >> "$log" 2>&1 &
 pid=$!;progress $pid


### PR DESCRIPTION
The link on the download frontpage is missing a dash.
