### PR TITLE
Spinner override

### DIFF
--- a/oab-java.sh
+++ b/oab-java.sh
@@ -18,7 +18,9 @@ if [[ $HOSTNAME == "" ]]; then
 fi
 
 # common ############################################################### START #
-sp="/-\|"
+if [ ! -v SPINNER ]; then
+    SPINNER="/-\|"
+fi
 log="${PWD}/`basename ${0}`.log"
 
 function error_msg() {
@@ -40,7 +42,9 @@ function ncecho() {
 }
 
 function spinny() {
-    echo -ne "\b${sp:i++%${#sp}:1}"
+    if [ -n "$SPINNER" ]; then
+        echo -ne "\b${SPINNER:i++%${#SPINNER}:1}"
+    fi
 }
 
 function progress() {


### PR DESCRIPTION
When using `./oab-java6` in a Vagrant shell provisioner each cycle of the spinner is printed to a new line resulting in a pretty useless print-out of

```
/
-
\
|
```

down your entire screen. This simple change allows the user to override the spinner string, effectively disabling it by setting it to a blank string.

For example:

```
[sudo] SPINNER="" ./oab-java.sh
```
